### PR TITLE
add autoloads

### DIFF
--- a/fvwm-mode.el
+++ b/fvwm-mode.el
@@ -835,7 +835,7 @@ Entry to this mode calls the value of `fvwm-mode-hook'"
     (fvwm-generate-hashmap)))
 
 ;;;###autoload
-(dolist (pattern '("\\.fvwm\\'" "\\`ConfigFvwm" "\\`FvwmScript-" "\\`FvwmForm-" "\\`FvwmTabs-"))
+(dolist (pattern '("\\.fvwm\\'" "/ConfigFvwm" "/FvwmScript-" "/FvwmForm-" "/FvwmTabs-"))
   (add-to-list 'auto-mode-alist (cons pattern 'fvwm-mode)))
 
 (provide 'fvwm-mode)


### PR DESCRIPTION
Adds autoload directives for the major mode and auto-mode-alist.  All config files that come with Fvwm should automatically use fvwm-mode, as well as files with a .fvwm extension.
