### PR TITLE
Load cl at compile time for using incf macro

### DIFF
--- a/fvwm-mode.el
+++ b/fvwm-mode.el
@@ -51,6 +51,10 @@
 ;; 
 ;;
 ;;; Code:
+
+(eval-when-compile
+  (require 'cl))
+
 (defconst fvwm-mode-version "1.6.4"
   "Version number for this release of `fvwm-mode'.")
 


### PR DESCRIPTION
This also fixes following byte-compile warning.

```
fvwm-mode.el:940:1:Warning: the following functions are not known to be defined: incf
```
